### PR TITLE
ci: update govulncheck Go patch

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.4"
+          go-version: "1.26.5"
           check-latest: true
           cache-dependency-path: go.sum
 


### PR DESCRIPTION
Update the govulncheck job from Go 1.26.4 to 1.26.5. Go 1.26.5 fixes GO-2026-5856/CVE-2026-42505 in crypto/tls, which currently fails the dependency PR security checks before those dependency changes are evaluated.