### PR TITLE
ci: update govulncheck Go patch

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.26.5"
+          go-version: "1.26.6"
           check-latest: true
           cache-dependency-path: go.sum
 


### PR DESCRIPTION
Update the govulncheck job from Go 1.26.5 to 1.26.6. Current scans report reachable GO-2026-6218, GO-2026-6090, GO-2026-6088, GO-2026-5972, and GO-2026-5026 standard-library vulnerabilities, all fixed in Go 1.26.6.