### PR TITLE
ci: pin lint to module Go version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,7 @@ jobs:
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: "stable"
+          go-version-file: go.mod
           cache-dependency-path: go.sum
 
       - name: golangci-lint


### PR DESCRIPTION
## Problem

`actions/setup-go` resolved `stable` to Go 1.27.0. The workflow still invokes golangci-lint v1.64.8, which cannot decode Go 1.27 export data and fails type checking before it can lint the repository.

## Root cause evidence

- failed job: https://github.com/x90skysn3k/brutespray/actions/runs/32867113072/job/97864986579
- runner resolved `stable version resolved as 1.27.0`
- local reproduction with `GOTOOLCHAIN=go1.27.0` produced the same `export data version 4 is greater than maximum supported version 2` error

## Change

Use `go-version-file: go.mod`, keeping lint on the repository-declared Go 1.26.1 toolchain instead of a moving alias.

## Verification

- current lint command passes with Go 1.26.1
- `go test ./...` passes