### PR TITLE
fix: close v2.7.1 release review gaps

### DIFF
--- a/brutespray/audit_command.go
+++ b/brutespray/audit_command.go
@@ -2,6 +2,7 @@ package brutespray
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/x90skysn3k/brutespray/v2/modules"
 )
@@ -11,7 +12,11 @@ func AuditCommand(args []string) error {
 	if len(args) != 2 || args[0] != "verify" {
 		return fmt.Errorf("usage: brutespray audit verify <audit.jsonl>")
 	}
-	if err := modules.VerifyAuditLog(args[1]); err != nil {
+	key := os.Getenv("BRUTESPRAY_AUDIT_HMAC_KEY")
+	if key == "" {
+		return fmt.Errorf("BRUTESPRAY_AUDIT_HMAC_KEY is required to verify an audit log")
+	}
+	if err := modules.VerifyAuditLog(args[1], []byte(key)); err != nil {
 		return fmt.Errorf("audit log verification failed: %w", err)
 	}
 	fmt.Printf("audit log verified: %s\n", args[1])

--- a/brutespray/audit_command_test.go
+++ b/brutespray/audit_command_test.go
@@ -8,8 +8,10 @@ import (
 )
 
 func TestAuditCommandVerify(t *testing.T) {
+	const auditKey = "test-audit-hmac-key"
+	t.Setenv("BRUTESPRAY_AUDIT_HMAC_KEY", auditKey)
 	path := filepath.Join(t.TempDir(), "audit.jsonl")
-	log, err := modules.NewAuditLog(path)
+	log, err := modules.NewAuditLog(path, []byte(auditKey))
 	if err != nil {
 		t.Fatalf("NewAuditLog: %v", err)
 	}
@@ -21,6 +23,13 @@ func TestAuditCommandVerify(t *testing.T) {
 	}
 	if err := AuditCommand([]string{"verify", path}); err != nil {
 		t.Fatalf("AuditCommand verify: %v", err)
+	}
+}
+
+func TestAuditCommandVerifyRequiresHMACKey(t *testing.T) {
+	t.Setenv("BRUTESPRAY_AUDIT_HMAC_KEY", "")
+	if err := AuditCommand([]string{"verify", filepath.Join(t.TempDir(), "audit.jsonl")}); err == nil {
+		t.Fatal("expected audit verification without BRUTESPRAY_AUDIT_HMAC_KEY to fail")
 	}
 }
 

--- a/brutespray/config.go
+++ b/brutespray/config.go
@@ -699,7 +699,7 @@ func ParseConfig() *Config {
 					cfg.TotalCombinations += len(users)
 				} else {
 					cfg.TotalCombinations += len(ParseInlineCreds(cfg.Creds))
-					if modules.IsPasswordOnlyService(service) {
+					if modules.IsSingleSecretService(service, cfg.ModuleParams) {
 						_, passwords, err := modules.GetUsersAndPasswords(&h, cfg.User, cfg.Password, version)
 						if err != nil {
 							fmt.Printf("Error loading wordlist for %s: %v\n", service, err)

--- a/brutespray/dispatch.go
+++ b/brutespray/dispatch.go
@@ -214,7 +214,7 @@ func (wp *WorkerPool) ProcessHost(host modules.Host, service string, combo strin
 			}
 		}
 	} else {
-		if modules.IsPasswordOnlyService(service) {
+		if modules.IsSingleSecretService(service, moduleParams) {
 			queuePassword := func(p string) bool {
 				// Check if we should stop before processing each credential
 				select {

--- a/brutespray/dispatch_password_only_test.go
+++ b/brutespray/dispatch_password_only_test.go
@@ -3,6 +3,7 @@ package brutespray
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -127,5 +128,55 @@ func TestProcessHostQueuesRedisInlinePasswordBeforeExplicitPassword(t *testing.T
 		if attempts[i].Password != wantPassword {
 			t.Fatalf("attempt %d password = %q, want %q", i, attempts[i].Password, wantPassword)
 		}
+	}
+}
+
+func TestProcessHostQueuesInfluxDBV2TokenOnce(t *testing.T) {
+	if os.Getenv("BRUTESPRAY_INFLUX_TOKEN_PROCESS_HOST_HELPER") != "1" {
+		cmd := exec.Command(os.Args[0], "-test.run=^TestProcessHostQueuesInfluxDBV2TokenOnce$", "-test.v")
+		cmd.Env = append(os.Environ(), "BRUTESPRAY_INFLUX_TOKEN_PROCESS_HOST_HELPER=1")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("influx token ProcessHost helper failed: %v\n%s", err, out)
+		}
+		return
+	}
+	originalInflux, ok := brute.Lookup("influxdb")
+	if !ok {
+		t.Fatal("influxdb brute function is not registered")
+	}
+	defer brute.Register("influxdb", originalInflux)
+	defer brute.GetCircuitBreaker().Reset("127.0.0.1:1")
+
+	brute.Register("influxdb", func(host string, port int, user, password string, timeout time.Duration, cm *modules.ConnectionManager, params brute.ModuleParams) *brute.BruteResult {
+		return &brute.BruteResult{ConnectionSuccess: true}
+	})
+
+	cm, err := modules.NewConnectionManager("", time.Millisecond)
+	if err != nil {
+		t.Fatalf("NewConnectionManager: %v", err)
+	}
+	users := filepath.Join(t.TempDir(), "users.txt")
+	if err := os.WriteFile(users, []byte("admin\noperator\n"), 0o600); err != nil {
+		t.Fatalf("write users: %v", err)
+	}
+
+	const wantToken = "influx-token"
+	sink := &captureDispatchEventSink{}
+	workerPool := NewWorkerPool(1, sink, 1, 1)
+	workerPool.noStats = true
+	host := modules.Host{Service: "influxdb", Host: "127.0.0.1", Port: 1}
+
+	workerPool.ProcessHost(host, "influxdb", "", users, wantToken, version, time.Millisecond, 1, t.TempDir(), cm, "", brute.ModuleParams{"mode": "v2"}, false)
+
+	attempts := sink.attemptResults()
+	if len(attempts) != 1 {
+		t.Fatalf("captured influxdb attempts = %d, want 1", len(attempts))
+	}
+	if attempts[0].User != "" {
+		t.Fatalf("influxdb token attempt user = %q, want empty", attempts[0].User)
+	}
+	if attempts[0].Password != wantToken {
+		t.Fatalf("influxdb token attempt password = %q, want %q", attempts[0].Password, wantToken)
 	}
 }

--- a/brutespray/plan.go
+++ b/brutespray/plan.go
@@ -1,11 +1,14 @@
 package brutespray
 
 import (
+	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/x90skysn3k/brutespray/v2/brute/badkeys"
@@ -27,10 +30,11 @@ type ExecutionPlan struct {
 
 // PlannedTarget describes a target that remains in scope.
 type PlannedTarget struct {
-	Service  string `json:"service"`
-	Host     string `json:"host"`
-	Port     int    `json:"port"`
-	Attempts int    `json:"attempts"`
+	Service        string `json:"service"`
+	Host           string `json:"host"`
+	Port           int    `json:"port"`
+	Attempts       int    `json:"attempts"`
+	CredentialHMAC string `json:"credential_hmac,omitempty"`
 }
 
 // PlanWarning is a stable warning emitted before execution.
@@ -55,6 +59,10 @@ func BuildExecutionPlan(cfg *Config, manifest EngagementManifest) (ExecutionPlan
 	if err := manifest.Validate(); err != nil {
 		return ExecutionPlan{}, err
 	}
+	credentialKey := []byte(manifest.Evidence.HMACKey)
+	if cfg.RequirePlanAck != "" && len(credentialKey) == 0 {
+		return ExecutionPlan{}, fmt.Errorf("plan acknowledgment requires evidence.hmac_key to bind credential inputs")
+	}
 	matcher, err := NewScopeMatcher(manifest.Scope)
 	if err != nil {
 		return ExecutionPlan{}, err
@@ -70,11 +78,17 @@ func BuildExecutionPlan(cfg *Config, manifest EngagementManifest) (ExecutionPlan
 			plan.ScopeRejects = append(plan.ScopeRejects, ScopeRejection{Service: host.Service, Host: host.Host, Port: host.Port, Reason: reason})
 			continue
 		}
-		attempts, err := estimateAttemptsForTarget(cfg, host)
+		attempts, credentialHMAC, err := estimateAttemptsForTarget(cfg, host, credentialKey)
 		if err != nil {
 			return ExecutionPlan{}, err
 		}
-		plan.Targets = append(plan.Targets, PlannedTarget{Service: host.Service, Host: host.Host, Port: host.Port, Attempts: attempts})
+		plan.Targets = append(plan.Targets, PlannedTarget{
+			Service:        host.Service,
+			Host:           host.Host,
+			Port:           host.Port,
+			Attempts:       attempts,
+			CredentialHMAC: credentialHMAC,
+		})
 		plan.TotalTargets++
 		plan.TotalAttempts += attempts
 		if host.Service == "wrapper" {
@@ -86,43 +100,110 @@ func BuildExecutionPlan(cfg *Config, manifest EngagementManifest) (ExecutionPlan
 	return plan, nil
 }
 
-func estimateAttemptsForTarget(cfg *Config, host modules.Host) (int, error) {
+func estimateAttemptsForTarget(cfg *Config, host modules.Host, credentialKey []byte) (int, string, error) {
+	mac := hmac.New(sha256.New, credentialKey)
+	hashEnabled := len(credentialKey) > 0
+	writeValue := func(value string) {
+		if !hashEnabled {
+			return
+		}
+		var size [8]byte
+		binary.BigEndian.PutUint64(size[:], uint64(len(value)))
+		_, _ = mac.Write(size[:])
+		_, _ = mac.Write([]byte(value))
+	}
+	writeValues := func(label string, values []string) {
+		writeValue(label)
+		for _, value := range values {
+			writeValue(value)
+		}
+	}
+	digest := func() string {
+		if !hashEnabled {
+			return ""
+		}
+		return hex.EncodeToString(mac.Sum(nil))
+	}
+
+	writeValue("brutespray.plan.credentials.v1")
+	writeValue(host.Service)
+	writeValue(host.Host)
+	writeValue(strconv.Itoa(host.Port))
+
 	if cfg.Combo != "" {
 		users, passwords := modules.GetUsersAndPasswordsCombo(&host, cfg.Combo, version)
-		return min(len(users), len(passwords)), nil
+		count := min(len(users), len(passwords))
+		writeValue("combo")
+		for i := range count {
+			writeValue(users[i])
+			writeValue(passwords[i])
+		}
+		return count, digest(), nil
 	}
-	attempts := len(ParseInlineCreds(cfg.Creds))
-	if modules.IsPasswordOnlyService(host.Service) {
+
+	inline := ParseInlineCreds(cfg.Creds)
+	attempts := len(inline)
+	if modules.IsSingleSecretService(host.Service, cfg.ModuleParams) {
+		writeValue("single-secret")
+		for _, pair := range inline {
+			writeValue(pair.Password)
+		}
 		if cfg.PasswordGen != nil {
-			return attempts + cfg.PasswordGen.Count(), nil
+			writeValue("generator")
+			writeValue(strconv.Itoa(cfg.PasswordGen.MinLen))
+			writeValue(strconv.Itoa(cfg.PasswordGen.MaxLen))
+			writeValue(string(cfg.PasswordGen.Charset))
+			return attempts + cfg.PasswordGen.Count(), digest(), nil
 		}
 		_, passwords, err := modules.GetUsersAndPasswords(&host, cfg.User, cfg.Password, version)
 		if err != nil {
-			return 0, err
+			return 0, "", err
 		}
-		return attempts + len(passwords), nil
+		writeValues("passwords", passwords)
+		return attempts + len(passwords), digest(), nil
 	}
 
+	writeValue("user-password")
+	for _, pair := range inline {
+		writeValue(pair.User)
+		writeValue(pair.Password)
+	}
 	users, passwords, err := modules.GetUsersAndPasswords(&host, cfg.User, cfg.Password, version)
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
+	writeValues("users", users)
 	passCount := len(passwords)
 	if cfg.PasswordGen != nil {
+		writeValue("generator")
+		writeValue(strconv.Itoa(cfg.PasswordGen.MinLen))
+		writeValue(strconv.Itoa(cfg.PasswordGen.MaxLen))
+		writeValue(string(cfg.PasswordGen.Charset))
 		passCount = cfg.PasswordGen.Count()
+	} else {
+		writeValues("passwords", passwords)
 	}
+	writeValue(normalizedScheduleMode(cfg))
+	writeValue(strconv.FormatBool(cfg.UseUsernameAsPass))
+	writeValue(strconv.FormatBool(cfg.UseReversedPass))
 
 	if host.Service == "ssh" && !cfg.NoBadKeys {
 		bundle, err := badkeys.Load()
 		if err != nil {
-			return 0, fmt.Errorf("loading bad-keys bundle: %w", err)
+			return 0, "", fmt.Errorf("loading bad-keys bundle: %w", err)
+		}
+		writeValue("ssh-badkeys")
+		for _, entry := range bundle {
+			writeValue(entry.Username)
+			writeValue(entry.PEMHash)
 		}
 		attempts += len(bundle)
 	}
 	if host.Service == "ssh" && cfg.BadKeysOnly {
-		return attempts, nil
+		return attempts, digest(), nil
 	}
-	return attempts + countCredentialPairs(users, passCount, normalizedScheduleMode(cfg), cfg.UseUsernameAsPass, cfg.UseReversedPass), nil
+	attempts += countCredentialPairs(users, passCount, normalizedScheduleMode(cfg), cfg.UseUsernameAsPass, cfg.UseReversedPass)
+	return attempts, digest(), nil
 }
 
 func countCredentialPairs(users []string, passwordCount int, mode string, useUsernameAsPass bool, useReversedPass bool) int {

--- a/brutespray/plan_test.go
+++ b/brutespray/plan_test.go
@@ -109,6 +109,73 @@ func TestBuildExecutionPlanHashIgnoresHostInputOrder(t *testing.T) {
 	}
 }
 
+func TestBuildExecutionPlanHashBindsCredentialContents(t *testing.T) {
+	passwords := filepath.Join(t.TempDir(), "passwords.txt")
+	if err := os.WriteFile(passwords, []byte("first-secret\n"), 0o600); err != nil {
+		t.Fatalf("write first password list: %v", err)
+	}
+	cfg := &Config{
+		Hosts:     []modules.Host{{Service: "ftp", Host: "10.0.0.1", Port: 21}},
+		User:      "root",
+		Password:  passwords,
+		NoBadKeys: true,
+	}
+	manifest := EngagementManifest{Evidence: ManifestEvidence{HMACKey: "plan-key"}}
+
+	first, err := BuildExecutionPlan(cfg, manifest)
+	if err != nil {
+		t.Fatalf("BuildExecutionPlan(first): %v", err)
+	}
+	if err := os.WriteFile(passwords, []byte("other-secret\n"), 0o600); err != nil {
+		t.Fatalf("replace password list: %v", err)
+	}
+	second, err := BuildExecutionPlan(cfg, manifest)
+	if err != nil {
+		t.Fatalf("BuildExecutionPlan(second): %v", err)
+	}
+	if first.TotalAttempts != second.TotalAttempts {
+		t.Fatalf("attempt counts differ: %d != %d", first.TotalAttempts, second.TotalAttempts)
+	}
+	if first.Hash == second.Hash {
+		t.Fatalf("plan hash did not bind credential contents: %s", first.Hash)
+	}
+}
+
+func TestBuildExecutionPlanAcknowledgementRequiresHMACKey(t *testing.T) {
+	cfg := &Config{
+		Hosts:          []modules.Host{{Service: "ftp", Host: "10.0.0.1", Port: 21}},
+		User:           "root",
+		Password:       "secret",
+		RequirePlanAck: "acknowledged-hash",
+	}
+
+	if _, err := BuildExecutionPlan(cfg, EngagementManifest{}); err == nil {
+		t.Fatal("expected plan acknowledgment without evidence.hmac_key to fail")
+	}
+}
+
+func TestBuildExecutionPlanCredentialHMACBindsSSHBadKeys(t *testing.T) {
+	cfg := &Config{
+		Hosts:     []modules.Host{{Service: "ssh", Host: "10.0.0.1", Port: 22}},
+		User:      "root",
+		Password:  "secret",
+		NoBadKeys: true,
+	}
+	manifest := EngagementManifest{Evidence: ManifestEvidence{HMACKey: "plan-key"}}
+	withoutBadKeys, err := BuildExecutionPlan(cfg, manifest)
+	if err != nil {
+		t.Fatalf("BuildExecutionPlan(without bad keys): %v", err)
+	}
+	cfg.NoBadKeys = false
+	withBadKeys, err := BuildExecutionPlan(cfg, manifest)
+	if err != nil {
+		t.Fatalf("BuildExecutionPlan(with bad keys): %v", err)
+	}
+	if withoutBadKeys.Targets[0].CredentialHMAC == withBadKeys.Targets[0].CredentialHMAC {
+		t.Fatal("credential HMAC did not bind SSH bad-key identities")
+	}
+}
+
 func TestBuildExecutionPlanCountsFilesInlineAndExtras(t *testing.T) {
 	dir := t.TempDir()
 	users := filepath.Join(dir, "users.txt")
@@ -161,12 +228,50 @@ func TestEstimateAttemptsForRedisCountsInlineCredentialAndExplicitPassword(t *te
 		Creds:    "ignored:redis-inline-secret",
 		Password: "base-secret",
 	}
-	got, err := estimateAttemptsForTarget(cfg, modules.Host{Service: "redis", Host: "10.0.0.1", Port: 6379})
+	got, _, err := estimateAttemptsForTarget(cfg, modules.Host{Service: "redis", Host: "10.0.0.1", Port: 6379}, nil)
 	if err != nil {
 		t.Fatalf("estimateAttemptsForTarget: %v", err)
 	}
 	if got != 2 {
 		t.Fatalf("attempts = %d, want 2", got)
+	}
+}
+
+func TestEstimateAttemptsForInfluxDBTokenModeIgnoresUsers(t *testing.T) {
+	users := filepath.Join(t.TempDir(), "users.txt")
+	if err := os.WriteFile(users, []byte("admin\noperator\n"), 0o600); err != nil {
+		t.Fatalf("write users: %v", err)
+	}
+	cfg := &Config{
+		User:         users,
+		Password:     "influx-token",
+		ModuleParams: map[string]string{"mode": "v2"},
+	}
+	got, _, err := estimateAttemptsForTarget(cfg, modules.Host{Service: "influxdb", Host: "10.0.0.1", Port: 8086}, nil)
+	if err != nil {
+		t.Fatalf("estimateAttemptsForTarget: %v", err)
+	}
+	if got != 1 {
+		t.Fatalf("attempts = %d, want one token attempt", got)
+	}
+}
+
+func TestEstimateAttemptsForInfluxDBV1KeepsUserPasswordPairs(t *testing.T) {
+	users := filepath.Join(t.TempDir(), "users.txt")
+	if err := os.WriteFile(users, []byte("admin\noperator\n"), 0o600); err != nil {
+		t.Fatalf("write users: %v", err)
+	}
+	cfg := &Config{
+		User:         users,
+		Password:     "influx-password",
+		ModuleParams: map[string]string{"mode": "v1"},
+	}
+	got, _, err := estimateAttemptsForTarget(cfg, modules.Host{Service: "influxdb", Host: "10.0.0.1", Port: 8086}, nil)
+	if err != nil {
+		t.Fatalf("estimateAttemptsForTarget: %v", err)
+	}
+	if got != 2 {
+		t.Fatalf("attempts = %d, want two user/password attempts", got)
 	}
 }
 
@@ -185,6 +290,12 @@ func TestParseConfigTotalCombinationsCountsInlineCredsWithoutCombo(t *testing.T)
 			os.Args = append(os.Args, "-s", "redis", "-H", "redis://127.0.0.1:6379", "-p", "base-secret")
 		case "ftp":
 			os.Args = append(os.Args, "-s", "ftp", "-H", "ftp://127.0.0.1:21", "-u", "admin", "-p", "base-secret")
+		case "influx-v2":
+			users := filepath.Join(t.TempDir(), "influx-users.txt")
+			if err := os.WriteFile(users, []byte("admin\noperator\n"), 0o600); err != nil {
+				t.Fatalf("write influx users: %v", err)
+			}
+			os.Args = append(os.Args, "-s", "influxdb", "-H", "influxdb://127.0.0.1:8086", "-u", users, "-p", "base-secret", "-m", "mode:v2")
 		case "combo":
 			os.Args = append(os.Args, "-s", "ftp", "-H", "ftp://127.0.0.1:21", "-C", "admin:base-secret")
 		default:
@@ -203,7 +314,7 @@ func TestParseConfigTotalCombinationsCountsInlineCredsWithoutCombo(t *testing.T)
 		return
 	}
 
-	for _, mode := range []string{"redis", "ftp", "combo"} {
+	for _, mode := range []string{"redis", "ftp", "influx-v2", "combo"} {
 		t.Run(mode, func(t *testing.T) {
 			cmd := exec.Command(os.Args[0], "-test.run=^TestParseConfigTotalCombinationsCountsInlineCredsWithoutCombo$", "-test.v")
 			cmd.Env = append(os.Environ(), "BRUTESPRAY_PARSECONFIG_TOTALS_HELPER="+mode)

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -50,12 +50,12 @@ policy:
   safe_margin: 1
   jitter_percent: 10
 evidence:
-  # redacted is safest for shareable reports; hash requires hmac_key.
+  # hmac_key is required for hash mode and --require-plan-ack.
   mode: redacted
-  # hmac_key: "replace-with-secret-engagement-key"
+  hmac_key: "SENTINEL_NOT_A_REAL_KEY"
 ```
 
-Use `--require-plan-ack <hash>` to require the exact dry-run hash before execution. This protects against accidental scope or credential-list drift between planning and running.
+Use `--require-plan-ack <hash>` to require the exact dry-run hash before execution. The engagement manifest must provide `evidence.hmac_key`; Brutespray uses it to bind the plan hash to the resolved credential contents without writing plaintext credentials into the plan. Changing a target, credential, or credential-list entry invalidates the acknowledgment.
 
 ## Lockout-Aware Scheduling
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -95,10 +95,14 @@ JSON attempt records may include:
 
 ## Audit log verification
 
-`brutespray audit verify <audit.jsonl>` validates a hash-chained JSONL audit log. Each event includes `sequence`, `prev_hash`, and `hash`; verification fails if an event is edited, removed, or reordered.
+`brutespray audit verify <audit.jsonl>` validates an HMAC-SHA256-chained JSONL audit log. Each event includes `sequence`, `prev_hash`, and `hash`; verification fails if an event is edited, removed, reordered, or authenticated with a different key. Supply the same key used by the audit writer through `BRUTESPRAY_AUDIT_HMAC_KEY`; the command fails closed when the variable is unset.
 
 ```bash
+export BRUTESPRAY_AUDIT_HMAC_KEY
+read -rsp 'Audit HMAC key: ' BRUTESPRAY_AUDIT_HMAC_KEY
+printf '\n'
 brutespray audit verify brutespray-audit.jsonl
+unset BRUTESPRAY_AUDIT_HMAC_KEY
 ```
 
 ## Finding records (JSONL)

--- a/modules/auditlog.go
+++ b/modules/auditlog.go
@@ -2,6 +2,7 @@ package modules
 
 import (
 	"bufio"
+	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -27,15 +28,19 @@ type AuditLog struct {
 	encoder  *json.Encoder
 	sequence int64
 	prevHash string
+	key      []byte
 }
 
-// NewAuditLog creates a new owner-readable audit log file.
-func NewAuditLog(path string) (*AuditLog, error) {
+// NewAuditLog creates a new owner-readable audit log protected by HMAC-SHA256.
+func NewAuditLog(path string, key []byte) (*AuditLog, error) {
+	if len(key) == 0 {
+		return nil, fmt.Errorf("audit HMAC key is required")
+	}
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("opening audit log: %w", err)
 	}
-	return &AuditLog{file: file, encoder: json.NewEncoder(file)}, nil
+	return &AuditLog{file: file, encoder: json.NewEncoder(file), key: append([]byte(nil), key...)}, nil
 }
 
 // Write appends one event with sequence, timestamp, and hash fields filled.
@@ -49,7 +54,7 @@ func (l *AuditLog) Write(event AuditEvent) error {
 		event.Timestamp = time.Now().UTC()
 	}
 	event.PrevHash = l.prevHash
-	event.Hash = hashAuditEvent(event)
+	event.Hash = hashAuditEvent(event, l.key)
 	if err := l.encoder.Encode(event); err != nil {
 		return fmt.Errorf("writing audit event: %w", err)
 	}
@@ -63,13 +68,20 @@ func (l *AuditLog) Close() error {
 		return nil
 	}
 	err := l.file.Close()
+	for i := range l.key {
+		l.key[i] = 0
+	}
+	l.key = nil
 	l.file = nil
 	l.encoder = nil
 	return err
 }
 
-// VerifyAuditLog verifies every event hash and previous-hash pointer.
-func VerifyAuditLog(path string) error {
+// VerifyAuditLog verifies every event HMAC and previous-HMAC pointer.
+func VerifyAuditLog(path string, key []byte) error {
+	if len(key) == 0 {
+		return fmt.Errorf("audit HMAC key is required")
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("opening audit log: %w", err)
@@ -90,7 +102,7 @@ func VerifyAuditLog(path string) error {
 		if event.PrevHash != prev {
 			return fmt.Errorf("event %d previous hash mismatch", sequence)
 		}
-		want := hashAuditEvent(event)
+		want := hashAuditEvent(event, key)
 		if event.Hash != want {
 			return fmt.Errorf("event %d hash mismatch", sequence)
 		}
@@ -102,9 +114,10 @@ func VerifyAuditLog(path string) error {
 	return nil
 }
 
-func hashAuditEvent(event AuditEvent) string {
+func hashAuditEvent(event AuditEvent, key []byte) string {
 	event.Hash = ""
 	data, _ := json.Marshal(event)
-	sum := sha256.Sum256(data)
-	return hex.EncodeToString(sum[:])
+	mac := hmac.New(sha256.New, key)
+	_, _ = mac.Write(data)
+	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/modules/auditlog_test.go
+++ b/modules/auditlog_test.go
@@ -6,9 +6,11 @@ import (
 	"testing"
 )
 
+var testAuditHMACKey = []byte("test-audit-hmac-key")
+
 func TestAuditLogHashChainVerifies(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.jsonl")
-	log, err := NewAuditLog(path)
+	log, err := NewAuditLog(path, testAuditHMACKey)
 	if err != nil {
 		t.Fatalf("NewAuditLog: %v", err)
 	}
@@ -21,14 +23,14 @@ func TestAuditLogHashChainVerifies(t *testing.T) {
 	if err := log.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if err := VerifyAuditLog(path); err != nil {
+	if err := VerifyAuditLog(path, testAuditHMACKey); err != nil {
 		t.Fatalf("VerifyAuditLog: %v", err)
 	}
 }
 
 func TestAuditLogDetectsTamper(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "audit.jsonl")
-	log, err := NewAuditLog(path)
+	log, err := NewAuditLog(path, testAuditHMACKey)
 	if err != nil {
 		t.Fatalf("NewAuditLog: %v", err)
 	}
@@ -46,7 +48,37 @@ func TestAuditLogDetectsTamper(t *testing.T) {
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if err := VerifyAuditLog(path); err == nil {
+	if err := VerifyAuditLog(path, testAuditHMACKey); err == nil {
 		t.Fatal("expected tamper verification failure")
+	}
+}
+
+func TestAuditLogRejectsDifferentHMACKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	log, err := NewAuditLog(path, testAuditHMACKey)
+	if err != nil {
+		t.Fatalf("NewAuditLog: %v", err)
+	}
+	if err := log.Write(AuditEvent{Type: "run_start", RunID: "run1"}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := log.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := VerifyAuditLog(path, []byte("different-key")); err == nil {
+		t.Fatal("expected verification with a different HMAC key to fail")
+	}
+}
+
+func TestAuditLogRequiresHMACKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	if _, err := NewAuditLog(path, nil); err == nil {
+		t.Fatal("expected NewAuditLog without an HMAC key to fail")
+	}
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := VerifyAuditLog(path, nil); err == nil {
+		t.Fatal("expected VerifyAuditLog without an HMAC key to fail")
 	}
 }

--- a/modules/service_descriptor.go
+++ b/modules/service_descriptor.go
@@ -1,5 +1,7 @@
 package modules
 
+import "strings"
+
 // CredentialMode describes the credential material a service consumes.
 type CredentialMode string
 
@@ -165,4 +167,18 @@ func DescriptorForService(service string) (ServiceDescriptor, bool) {
 func IsPasswordOnlyService(service string) bool {
 	descriptor, ok := DescriptorForService(service)
 	return ok && descriptor.CredentialMode == CredentialPasswordOnly
+}
+
+// IsSingleSecretService reports whether one secret should be attempted without
+// multiplying it across usernames for the effective module mode.
+func IsSingleSecretService(service string, params map[string]string) bool {
+	descriptor, ok := DescriptorForService(service)
+	if !ok {
+		return false
+	}
+	mode := descriptor.CredentialMode
+	if descriptor.Name == "influxdb" && strings.EqualFold(strings.TrimSpace(params["mode"]), "v1") {
+		mode = CredentialUserPassword
+	}
+	return mode == CredentialPasswordOnly || mode == CredentialToken
 }


### PR DESCRIPTION
## Release blockers fixed

- bind acknowledged plan hashes to resolved credential contents with keyed HMACs, including SSH bad-key username/PEM identities
- require `evidence.hmac_key` when `--require-plan-ack` is used
- queue and count InfluxDB v2 tokens once while preserving InfluxDB v1 user/password behavior
- authenticate audit chains with HMAC-SHA256 and require `BRUTESPRAY_AUDIT_HMAC_KEY` for verification

## Verification

- focused tests were written first and reproduced all five failure modes
- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...` — 0 issues
- `go test ./... -count=1 -race -v` — 5 packages passed, 3 packages with no tests, 3 intentional skips
- final independent review: Ready to merge, no findings

This updates open release PR #327 after merge.