### PR TITLE
release: v2.7.2 print-hosts safety patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Brutespray
 
-![Version](https://img.shields.io/badge/Version-2.7.1-red) [![goreleaser](https://github.com/x90skysn3k/brutespray/actions/workflows/release.yml/badge.svg)](https://github.com/x90skysn3k/brutespray/actions/workflows/release.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/x90skysn3k/brutespray/v2)](https://goreportcard.com/report/github.com/x90skysn3k/brutespray/v2) [![GitHub stars](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fx90skysn3k%2Fbrutespray&query=%24.stargazers_count&label=Stars&logo=github)](https://github.com/x90skysn3k/brutespray/stargazers)
+![Version](https://img.shields.io/badge/Version-2.7.2-red) [![goreleaser](https://github.com/x90skysn3k/brutespray/actions/workflows/release.yml/badge.svg)](https://github.com/x90skysn3k/brutespray/actions/workflows/release.yml) [![Go Report Card](https://goreportcard.com/badge/github.com/x90skysn3k/brutespray/v2)](https://goreportcard.com/report/github.com/x90skysn3k/brutespray/v2) [![GitHub stars](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fapi.github.com%2Frepos%2Fx90skysn3k%2Fbrutespray&query=%24.stargazers_count&label=Stars&logo=github)](https://github.com/x90skysn3k/brutespray/stargazers)
 
 Created by: Shane Young/@x90sky && Jacob Robles/@shellfail
 

--- a/brutespray/brutespray.go
+++ b/brutespray/brutespray.go
@@ -98,6 +98,11 @@ func Execute() {
 		}
 	}
 
+	if cfg.PrintHosts {
+		PrintHostTable(cfg.Hosts)
+		return
+	}
+
 	totalHosts := len(cfg.Hosts)
 
 	configureCircuitBreaker(cfg)
@@ -320,10 +325,6 @@ func executeLegacy(cfg *Config, cm *modules.ConnectionManager, totalHosts int, e
 	// Register signal handler BEFORE launching the goroutine that reads from it
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-
-	if cfg.PrintHosts {
-		PrintHostTable(cfg.Hosts)
-	}
 
 	if cfg.SocksProxy != "" {
 		modules.PrintfColored(pterm.FgLightYellow, "Socks5 Proxy: %s\n", cfg.SocksProxy)

--- a/brutespray/config.go
+++ b/brutespray/config.go
@@ -19,7 +19,7 @@ var masterServiceList = brute.Services()
 
 var BetaServiceList = []string{"asterisk", "nntp", "oracle", "xmpp", "ldap", "ldaps", "winrm", "ftps", "smtp-vrfy", "rexec", "rlogin", "rsh", "wrapper", "http-form", "https-form", "http-template", "svn", "socks5-auth", "neo4j", "cassandra"}
 
-var version = "2.7.1"
+var version = "2.7.2"
 var NoColorMode bool
 
 func init() {

--- a/brutespray/print_hosts_test.go
+++ b/brutespray/print_hosts_test.go
@@ -1,0 +1,50 @@
+package brutespray
+
+import (
+	"flag"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestExecutePrintHostsExitsBeforeCredentialAttempts(t *testing.T) {
+	if os.Getenv("BRUTESPRAY_PRINT_HOSTS_HELPER") == "1" {
+		originalArgs := os.Args
+		originalCommandLine := flag.CommandLine
+		defer func() {
+			os.Args = originalArgs
+			flag.CommandLine = originalCommandLine
+		}()
+
+		os.Args = []string{
+			os.Args[0],
+			"-q", "-nc", "--no-tui", "-P",
+			"-H", "ftp://127.0.0.1:1",
+			"-u", "print-hosts-user",
+			"-p", "print-hosts-password",
+			"-r", "0",
+			"-t", "1",
+			"-T", "1",
+			"-w", "10ms",
+			"-o", t.TempDir(),
+		}
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+		Execute()
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestExecutePrintHostsExitsBeforeCredentialAttempts$", "-test.v")
+	cmd.Env = append(os.Environ(), "BRUTESPRAY_PRINT_HOSTS_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("print-hosts helper failed: %v\n%s", err, out)
+	}
+	output := string(out)
+	if !strings.Contains(output, "127.0.0.1") || !strings.Contains(output, "ftp on port 1") {
+		t.Fatalf("parsed host table missing:\n%s", output)
+	}
+	if strings.Contains(output, "Testing credentials") || strings.Contains(output, "Processing host") {
+		t.Fatalf("-P continued into credential attempts:\n%s", output)
+	}
+}


### PR DESCRIPTION
## v2.7.2

Patch release for the `-P` control-flow bug found during published v2.7.1 artifact verification.

### Fix

`-P` now prints parsed, scope-filtered hosts and exits before connection-manager, output, checkpoint, session-log, worker, TUI, or credential-attempt setup. This matches the documented `Print parsed hosts and exit` contract for both legacy and TUI defaults.

### Verification

- regression test reproduced v2.7.1 continuing into attempts before the fix
- direct `go run ... -P` smoke prints the host table with no attempt output
- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...` — 0 issues
- `go test ./... -count=1 -race -v` — 5 packages passed, 3 no tests, 3 intentional skips
- GoReleaser cross-platform snapshot built all 9 targets
- PR #329 passed unit, integration, lint, govulncheck, and dependency-review gates
- independent review: Ready to merge, no findings