### PR TITLE
fix(ci): run star history on automation branch to avoid protected main

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -5,6 +5,10 @@ on:
     - cron: "17 3 * * *"
   watch:
     types: [started]
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/star-history.yml
   workflow_dispatch:
 
 permissions:
@@ -19,8 +23,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
-      - uses: narayann7/star-history-action@a68d8f9d67ca20d55b682a264e69152dcf326e9c # v1.0.5
+      # Main requires pull requests. Keep generated assets on an automation
+      # branch so scheduled refreshes never try to bypass that protection.
+      - name: Check out chart branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --heads origin star-history >/dev/null; then
+            git fetch origin refs/heads/star-history:refs/remotes/origin/star-history
+            git switch --force-create star-history origin/star-history
+          else
+            git switch --create star-history
+            git push --set-upstream origin star-history
+          fi
+
+      - uses: narayann7/star-history-action@12543ab7352b91fb7c5eb0c4fbb39772baa0c168 # v1.0.6
         with:
           repos: ${{ github.repository }}
           output-dir: assets/star-history
@@ -28,8 +48,6 @@ jobs:
           type: Date
           themes: light,dark
           width: "800"
-          update-readme: "true"
-          readme: README.md
-          readme-format: picture
+          update-readme: "false"
           commit: "true"
           commit-message: "chore: update star history [skip ci]"

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Print discovered services from a scan file with `-P -q`:
 
 <!-- star-history:start -->
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/star-history/star-history-dark.svg">
-  <img alt="Star history" src="assets/star-history/star-history-light.svg">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/x90skysn3k/brutespray/star-history/assets/star-history/star-history-dark.svg">
+  <img alt="Star history" src="https://raw.githubusercontent.com/x90skysn3k/brutespray/star-history/assets/star-history/star-history-light.svg">
 </picture>
 <!-- star-history:end -->


### PR DESCRIPTION
## Problem

The Star History workflow fails on every schedule/watch run (16 failures since Aug 26).

The `narayann7/star-history-action` commits generated charts and pushes to whatever branch HEAD is on (`git push origin HEAD:$(git rev-parse --abbrev-ref HEAD)`). The committed workflow checked out `main` and ran the action there, so the push targeted `main` and was rejected by the protected-branch hook:

```
[main 779a9fe] chore: update star history [skip ci]
remote: error: GH006: Protected branch update failed for refs/heads/main.
! [remote rejected] HEAD -> main (protected branch hook declined)
```

Confirmed this is branch protection, not non-fast-forward (rebase reported "up to date") and not token scope (`contents: write`, rejection comes from the server-side protected-branch hook).

## Fix

- Check out a dedicated `star-history` automation branch before running the action, so it commits and pushes there (created on first run if absent) instead of protected `main`.
- Point the README star-history embed at the `star-history` branch raw URLs.
- Bump the action v1.0.5 → v1.0.6 and drop the README auto-update (assets now live on the automation branch).
- Add a `push` trigger on `star-history.yml` changes so future edits re-validate the workflow.

## Verification

After merge, the workflow triggers on the main push; the action creates the `star-history` branch and pushes to it (unprotected), which should succeed.